### PR TITLE
Fast node lookup

### DIFF
--- a/src/ast-dereferencer.ts
+++ b/src/ast-dereferencer.ts
@@ -11,6 +11,7 @@ export function astDereferencer(solcOutput: SolcOutput): ASTDereferencer {
   const asts = Array.from(Object.values(solcOutput.sources), s => s.ast);
   const cache = new Map<number, Node>();
 
+
   function deref<T extends NodeType>(nodeType: T | readonly T[], id: number): NodeTypeMap[T] {
     if (!isArray(nodeType)) {
       nodeType = [nodeType];

--- a/src/node-info.ts
+++ b/src/node-info.ts
@@ -1,6 +1,4 @@
-import {ContractDefinition, SourceLocation, SourceUnit} from '../types';
-import { findAll } from '../utils';
-import { Node, NodeType, NodeTypeMap } from '../node';
+import { Node, NodeType } from '../node';
 import type { SolcOutput } from '../solc';
 
 const util = require('util')
@@ -42,7 +40,7 @@ export class NodeInfoResolver {
                 // @ts-ignore
                 const member: Node[] = Array.isArray(node[key]) ? node[key] : [node[key]];
                 for (const item of member) {
-                    if (('id' in item) && ('src' in item)) {
+                    if (item && ('id' in item) && ('src' in item)) {
                         this.addProps(path, node, item);
                     }
                 }

--- a/src/node-info.ts
+++ b/src/node-info.ts
@@ -1,4 +1,4 @@
-import { Node, NodeType } from '../node';
+import { Node } from '../node';
 import type { SolcOutput } from '../solc';
 
 const util = require('util')
@@ -37,8 +37,8 @@ export class NodeInfoResolver {
         // console.log(util.inspect(nodeKeys, { showHidden: false, depth: null, colors: true }));
         nodeKeys.forEach( ( key ) => {
             if (key in node) {
-                // @ts-ignore
-                const member: Node[] = Array.isArray(node[key]) ? node[key] : [node[key]];
+                const childNode = node[key as keyof Node];
+                const member: Node[] = Array.isArray(childNode) ? childNode as Node[] : [childNode as unknown as Node];
                 for (const item of member) {
                     if (item && ('id' in item) && ('src' in item)) {
                         this.addProps(path, node, item);

--- a/src/node-info.ts
+++ b/src/node-info.ts
@@ -1,0 +1,52 @@
+import {ContractDefinition, SourceLocation, SourceUnit} from '../types';
+import { findAll } from '../utils';
+import { Node, NodeType, NodeTypeMap } from '../node';
+import type { SolcOutput } from '../solc';
+
+const util = require('util')
+
+export interface NODEINFO {
+    path: string;
+    scopeNode: Node | undefined;
+    node: Node;
+}
+
+export class NodeInfoResolver {
+    private fastNodeLookup: Map<number, NODEINFO> = new Map<number, NODEINFO>();
+    private finder = require('../finder.json');
+
+    constructor(readonly output: SolcOutput) {
+
+        for (const source in this.output.sources) {
+            const sUnit = this.output.sources[source].ast;
+            this.addProps(sUnit.absolutePath, undefined, sUnit);
+        }
+    }
+
+    // grab a node id
+    public getNodeInfo(id: number) : NODEINFO | undefined {
+        return this.fastNodeLookup.get(id);
+    }
+
+    private addProps(path: string, scopeNode: Node | undefined, node: Node) {
+        const nodeKeys: string[] = this.finder.ArrayTypeName[node.nodeType] ?? [];
+        this.fastNodeLookup.set(node.id, {
+            path: path,
+            scopeNode: scopeNode,
+            node: node,
+        });
+
+        // console.log(util.inspect(nodeKeys, { showHidden: false, depth: null, colors: true }));
+        nodeKeys.forEach( ( key ) => {
+            if (key in node) {
+                // @ts-ignore
+                const member: Node[] = Array.isArray(node[key]) ? node[key] : [node[key]];
+                for (const item of member) {
+                    if (('id' in item) && ('src' in item)) {
+                        this.addProps(path, node, item);
+                    }
+                }
+            }
+        });
+    }
+}

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -16,3 +16,5 @@ export function astDereferencer(solcOutput: SolcOutput): ASTDereferencer;
 export type SrcDecoder = (node: { src: string }) => string;
 
 export function srcDecoder(solcInput: SolcInput, solcOutput: SolcOutput): SrcDecoder;
+
+export { NodeInfoResolver, NODEINFO} from "./src/node-info";

--- a/utils.js
+++ b/utils.js
@@ -24,3 +24,6 @@ module.exports.astDereferencer = astDereferencer;
 
 const { srcDecoder } = require('./dist/src-decoder');
 module.exports.srcDecoder = srcDecoder;
+
+const { NodeInfoResolver } = require('./dist/node-info');
+module.exports.NodeInfoResolver = NodeInfoResolver;


### PR DESCRIPTION
This code here adds a fast lookup map for nodes that also contain the source file the node came from.  It reduces the transpile time by a factor of 10x.

For a sample usage that should be integrated into the OZ transpiler, please look at this updated ast-resolver.ts from the transpiler fork.

https://github.com/GeniusVentures/openzeppelin-transpiler/blob/diamond/src/ast-resolver.ts
