### PR TITLE
Update Node version used in `update-solc` workflow

### DIFF
--- a/.github/workflows/update-solc.yml
+++ b/.github/workflows/update-solc.yml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.x
+        node-version: 22.x
         cache: npm
     - run: |
         set -euo pipefail


### PR DESCRIPTION
#46 was opened automatically because of insignificant changes in `package-lock.json` caused by npm version differences.